### PR TITLE
FEAT:(CORE) ON_ERROR 로깅 버전 추가 및 LogEnabled와 Interceptor 책임 분리

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -52,7 +52,7 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
-version = '1.0.8'
+version = '1.0.9'
 
 publishing {
     repositories {

--- a/lib/src/main/java/kr/teamo2/utils/interceptor/HttpLoggingInterceptor.java
+++ b/lib/src/main/java/kr/teamo2/utils/interceptor/HttpLoggingInterceptor.java
@@ -1,0 +1,37 @@
+package kr.teamo2.utils.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.teamo2.utils.trackingUtil.TrackingIdContext;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Log4j2
+@Component
+public class HttpLoggingInterceptor implements HandlerInterceptor {
+
+    private static final String START_TIME_ATTRIBUTE = "startTime";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        request.setAttribute(START_TIME_ATTRIBUTE, System.currentTimeMillis());
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+        Long startTime = (Long) request.getAttribute(START_TIME_ATTRIBUTE);
+        if (startTime != null) {
+            long duration = System.currentTimeMillis() - startTime;
+            String method = request.getMethod();
+            String uri = request.getRequestURI();
+            String queryString = request.getQueryString();
+            String fullUrl = queryString != null ? uri + "?" + queryString : uri;
+            int status = response.getStatus();
+            String trackingId = TrackingIdContext.getTrackingId();
+
+            log.info("{}: {} | [{}] {} - {}ms", trackingId, status, method, fullUrl, duration);
+        }
+    }
+}

--- a/lib/src/main/java/kr/teamo2/utils/interceptor/RestTemplateLoggingInterceptor.java
+++ b/lib/src/main/java/kr/teamo2/utils/interceptor/RestTemplateLoggingInterceptor.java
@@ -1,0 +1,49 @@
+package kr.teamo2.utils.interceptor;
+
+import java.io.IOException;
+import kr.teamo2.utils.trackingUtil.TrackingIdContext;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+@Log4j2
+public class RestTemplateLoggingInterceptor implements ClientHttpRequestInterceptor {
+
+    @Override
+    public ClientHttpResponse intercept(
+        HttpRequest request,
+        byte[] body,
+        ClientHttpRequestExecution execution) throws IOException {
+
+        long startTime = System.currentTimeMillis();
+
+        try {
+            ClientHttpResponse response = execution.execute(request, body);
+            long duration = System.currentTimeMillis() - startTime;
+
+            String host = request.getURI().getHost();
+            String fullUrl = request.getURI().toString();
+            log.info("{}: {} | [{}] {} -> {} - {}ms",
+                TrackingIdContext.getTrackingId(),
+                response.getStatusCode().value(),
+                request.getMethod(),
+                fullUrl,
+                host,
+                duration);
+
+            return response;
+        } catch (Exception e) {
+            long duration = System.currentTimeMillis() - startTime;
+            String fullUrl = request.getURI().toString();
+            log.error("{}: ERROR | [{}] {} - {}ms - {}",
+                TrackingIdContext.getTrackingId(),
+                request.getMethod(),
+                fullUrl,
+                duration,
+                e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/lib/src/main/java/kr/teamo2/utils/loggingUtil/ApiLogger.java
+++ b/lib/src/main/java/kr/teamo2/utils/loggingUtil/ApiLogger.java
@@ -1,12 +1,15 @@
 package kr.teamo2.utils.loggingUtil;
 
+import static kr.teamo2.utils.trackingUtil.TrackingIdContext.getTrackingId;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.teamo2.utils.HttpServletUtil;
+import kr.teamo2.utils.trackingUtil.TrackingIdContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.aspectj.lang.JoinPoint;
-import org.springframework.http.HttpMethod;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
@@ -18,54 +21,74 @@ public class ApiLogger extends LoggingPointCut {
     private final ObjectMapper objectMapper;
 
     public void beforeLog(JoinPoint joinPoint) {
-        String trackingId = HttpServletUtil.generateAndSetTrackingId();
+        LogEnabled logEnabled = ((MethodSignature) joinPoint.getSignature()).getMethod().getAnnotation(LogEnabled.class);
+        String customTrackingId = logEnabled != null ? logEnabled.trackingId() : "";
 
-        Object[] args = joinPoint.getArgs();
+        String trackingId = !customTrackingId.isEmpty() ? customTrackingId :
+            (getTrackingId() != null ? getTrackingId() :
+                HttpServletUtil.generateAndSetTrackingId());
 
-        String urlAndQueryString = HttpServletUtil.getUrlAndQueryString();
-        RequestLog.RequestLogBuilder requestLogBuilder = RequestLog.builder()
-            .requestID(trackingId)
-            .url(urlAndQueryString)
-            .method(HttpServletUtil.getHttpMethod())
-            .header(HttpServletUtil.requestToHeaderMap());
+        TrackingIdContext.setTrackingId(trackingId);
 
-        for (Object o : args) {
-            if (HttpServletUtil.getHttpMethod().equals(HttpMethod.POST.name())) {
-                try {
-                    String bodyJson = objectMapper.writeValueAsString(o);
-                    requestLogBuilder.body(bodyJson);
-                } catch (Exception e) {
-                    requestLogBuilder.body("Failed to serialize body: " + e.getMessage());
-                }
-            }
+        Version version = logEnabled != null ? logEnabled.version() : Version.FULL;
+
+        if (version == Version.ON_ERROR) {
+            return;
         }
-        log.info("[ApiLogger] - {}", requestLogBuilder.build());
+
+        requestLog(joinPoint);
     }
 
-    public void afterLog(ResponseEntity response) {
-        ResponseLog responseLog;
+    public void afterLog(ResponseEntity response, JoinPoint joinPoint) {
+        LogEnabled logEnabled = ((MethodSignature) joinPoint.getSignature()).getMethod().getAnnotation(LogEnabled.class);
+        Version version = logEnabled != null ? logEnabled.version() : Version.FULL;
         boolean isSuccessful = response.getStatusCode().is2xxSuccessful();
 
-        Object body = response.getBody();
-        String bodyJson = null;
-
-        try {
-            bodyJson = this.objectMapper.writeValueAsString(body);
-        } catch (JsonProcessingException e) {
-            bodyJson = String.valueOf(body);
+        if(version == Version.ON_ERROR){
+            if(isSuccessful){
+                return;
+            }
+            else {
+                requestLog(joinPoint);
+                responseLog(response);
+                return;
+            }
         }
 
-        responseLog = isSuccessful
-            ? ResponseLog.initSuccess()
-            .requestId(HttpServletUtil.getTrackingId())
-            .body(bodyJson)
-            .build()
-            : ResponseLog.initFail()
-                .requestId(HttpServletUtil.getTrackingId())
-                .body(bodyJson)
-                .statusCode(response.getStatusCode().value())
-                .build();
+        responseLog(response);
+    }
 
-        log.info("[ApiLogger] - {}", responseLog);
+    private void requestLog(JoinPoint joinPoint) {
+        String trackingId = getTrackingId();
+        Object[] args = joinPoint.getArgs();
+        RequestLog.RequestLogBuilder requestLogBuilder = RequestLog.builder();
+
+        for (Object o : args) {
+            try {
+                String requestJson = objectMapper.writeValueAsString(o);
+                requestLogBuilder.request(requestJson);
+            } catch (Exception e) {
+                requestLogBuilder.request("Failed to serialize request: " + e.getMessage());
+            }
+        }
+        log.info("{}: {}", trackingId, requestLogBuilder.build());
+    }
+
+    private void responseLog(ResponseEntity response) {
+        String trackingId = getTrackingId();
+        ResponseLog responseLog;
+        Object body = response.getBody();
+        String responseJson = null;
+        try {
+            responseJson = this.objectMapper.writeValueAsString(body);
+        } catch (JsonProcessingException e) {
+            responseJson = String.valueOf(body);
+        }
+
+        responseLog = ResponseLog.builder()
+            .response(responseJson)
+            .build();
+
+        log.info("{}: {}", trackingId, responseLog);
     }
 }

--- a/lib/src/main/java/kr/teamo2/utils/loggingUtil/ApiLoggingAspect.java
+++ b/lib/src/main/java/kr/teamo2/utils/loggingUtil/ApiLoggingAspect.java
@@ -25,7 +25,7 @@ public class ApiLoggingAspect extends LoggingPointCut {
     }
 
     @AfterReturning(value = "logEnabled()", returning = "response")
-    public void apiAfterLogging(ResponseEntity response) {
-        apiLogger.afterLog(response);
+    public void apiAfterLogging(JoinPoint joinPoint, ResponseEntity response) {
+        apiLogger.afterLog(response, joinPoint);
     }
 }

--- a/lib/src/main/java/kr/teamo2/utils/loggingUtil/LogEnabled.java
+++ b/lib/src/main/java/kr/teamo2/utils/loggingUtil/LogEnabled.java
@@ -17,4 +17,8 @@ public @interface LogEnabled {
     String collection() default "";
 
     boolean isEnabled() default true;
+
+    Version version() default Version.FULL;
+
+    String trackingId() default "";
 }

--- a/lib/src/main/java/kr/teamo2/utils/loggingUtil/RequestLog.java
+++ b/lib/src/main/java/kr/teamo2/utils/loggingUtil/RequestLog.java
@@ -14,13 +14,5 @@ import lombok.ToString;
 @ToString
 public class RequestLog {
 
-    private String requestID;
-
-    private String url;
-
-    private String method;
-
-    private Object header;
-
-    private Object body;
+    private Object request;
 }

--- a/lib/src/main/java/kr/teamo2/utils/loggingUtil/ResponseLog.java
+++ b/lib/src/main/java/kr/teamo2/utils/loggingUtil/ResponseLog.java
@@ -13,28 +13,14 @@ import lombok.ToString;
 @ToString
 public class ResponseLog {
 
-    private String requestID;
-
-    private Integer statusCode;
-
-    private Object body;
+    private Object response;
 
     private boolean isError;
 
-    @Builder(builderClassName = "InitSuccess", builderMethodName = "initSuccess")
-    public ResponseLog(String requestId, Object body) {
-        this.requestID = requestId;
-        this.statusCode = 200;
-        this.body = body;
+    @Builder
+    public ResponseLog(Object response) {
+        this.response = response;
         this.isError = false;
-    }
-
-    @Builder(builderClassName = "InitFail", builderMethodName = "initFail")
-    public ResponseLog(String requestId, Object body, Integer statusCode) {
-        this.requestID = requestId;
-        this.statusCode = statusCode;
-        this.body = body;
-        this.isError = true;
     }
 }
 

--- a/lib/src/main/java/kr/teamo2/utils/loggingUtil/Version.java
+++ b/lib/src/main/java/kr/teamo2/utils/loggingUtil/Version.java
@@ -1,0 +1,6 @@
+package kr.teamo2.utils.loggingUtil;
+
+public enum Version {
+    ON_ERROR,
+    FULL
+}

--- a/lib/src/main/java/kr/teamo2/utils/trackingUtil/TrackingIdContext.java
+++ b/lib/src/main/java/kr/teamo2/utils/trackingUtil/TrackingIdContext.java
@@ -1,0 +1,21 @@
+package kr.teamo2.utils.trackingUtil;
+
+public class TrackingIdContext {
+
+    private static final ThreadLocal<String> trackingIdHolder = new ThreadLocal<>();
+
+    public TrackingIdContext() {
+    }
+
+    public static String getTrackingId() {
+        return trackingIdHolder.get();
+    }
+
+    public static void setTrackingId(String trackingId) {
+        trackingIdHolder.set(trackingId);
+    }
+
+    public static void clear() {
+        trackingIdHolder.remove();
+    }
+}

--- a/lib/src/main/java/kr/teamo2/utils/trackingUtil/TrackingIdFilter.java
+++ b/lib/src/main/java/kr/teamo2/utils/trackingUtil/TrackingIdFilter.java
@@ -1,0 +1,31 @@
+package kr.teamo2.utils.trackingUtil;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import kr.teamo2.utils.HttpServletUtil;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class TrackingIdFilter extends OncePerRequestFilter {
+
+    private static final String TRACKING_ID_HEADER = "X-Tracking-ID";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain)
+        throws ServletException, IOException {
+        try {
+            String trackingId = request.getHeader(TRACKING_ID_HEADER);
+            if (trackingId == null) {
+                trackingId = HttpServletUtil.generateAndSetTrackingId();
+            }
+            TrackingIdContext.setTrackingId(trackingId);
+            filterChain.doFilter(request, response);
+        } finally {
+            TrackingIdContext.clear();
+        }
+    }
+}


### PR DESCRIPTION
prod PR입니다
---

### 작업 내용
**[LogEnabled]**
- LogEnabled version=ON_ERROR 추가
   - 언제나 request, response를 출력하는게 아니라 API 요청 결과가 success가 아닐 경우에만 로그를 출력하고 싶을 때 ON_ERROR버전을 사용할 수 있도록 추가했습니다.
- 로깅 형식 request, response 중심으로 변경

**[TrackingIdFilter]**
- ThreadLocal에 trackingId를 저장하는 필터 추가
- 기존에 LogEnabled 를 사용한 로깅 시, 하나의 HTTP 요청에 대해서 여러 LogEnabled를 사용하면 trackingId가 변경되는 문제 해결
- 요청 헤더에 X-Tracking-ID 가 존재하는 경우 해당 데이터를 trackingId로 사용

**[Interceptor]**
- HttpLoggingInterceptor 추가
- RestTemplateLoggingInterceptor 추가
- LogEnabled는 기본적으로 request와 response를 저장하는 역할로 사용하고, 통신 로그는 Interceptor를 통해 남기는 것으로 책임 분리
   - LogEnabled는 HttpServlet을 통해서 url을 로깅하기 때문에 하나의 Http요청에서 여러 서버로 추가 요청이 들어갈 때, 해당 url을 로깅할 수 없음 (request, response에서 포함되어 있는 경우에만 확인할 수 있음)
   - 예) /vehicleAvailRate 요청에서 {rentcar-api}/v2/vehicles 요청을 하게 되면 요청 url이 로깅되지 않음 

### 추가
이전 버전 (version = '1.0.8') 을 사용하던 서버에서 version = '1.0.9' 로 변경했을 때 논리적 오류는 발생하지 않습니다.
하지만 LogEnabled의 로깅 형식이 request, response 중심으로 변경됩니다