### PR TITLE
FEAT:(CORE) 로깅 규정 완화 Response 클래스의 영향을 받지 않도록 수정

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -52,7 +52,7 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
-version = '1.0.9'
+version = '1.0.10'
 
 publishing {
     repositories {

--- a/lib/src/main/java/kr/teamo2/utils/loggingUtil/ApiLoggingAspect.java
+++ b/lib/src/main/java/kr/teamo2/utils/loggingUtil/ApiLoggingAspect.java
@@ -5,7 +5,6 @@ import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
-import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
@@ -18,10 +17,7 @@ public class ApiLoggingAspect extends LoggingPointCut {
 
     @Before("logEnabled()")
     public void apiBeforeLogging(JoinPoint joinPoint) {
-        Class<?> returnType = ((MethodSignature) joinPoint.getSignature()).getReturnType();
-        if (ResponseEntity.class.isAssignableFrom(returnType)) {
-            apiLogger.beforeLog(joinPoint);
-        }
+        apiLogger.beforeLog(joinPoint);
     }
 
     @AfterReturning(value = "logEnabled()", returning = "response")


### PR DESCRIPTION
### 작업내용
- LogEnabled 어노테이션의 로깅 조건 중 반환값이 ResponseEntity 클래스일 때 로깅을 수행하도록 되어있었습니다
- 반환값이 DTO일때도 로깅할 수 있도록 해당 조건을 제거했습니다